### PR TITLE
Add moment to fix age issue - issue #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "angular-last-fm-scrobbles": "^0.1.0",
     "fs-extra": "^8.1.0",
     "git-describe": "^4.0.4",
+    "moment": "^2.24.0",
     "rxjs": "^6.5.4",
     "zone.js": "~0.10.2"
   },

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { LastFmScrobblesComponent } from 'angular-last-fm-scrobbles';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-home',
@@ -43,9 +44,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   getAge() : number {
-    const bday = new Date(1995,2,25);
-    const timeDiff = Math.abs(Date.now() - bday.getTime())
-    return Math.floor((timeDiff / (1000 * 3600 * 24))/365.25); 
+	return moment().diff('1995-2-25', 'years');
   }
 
 


### PR DESCRIPTION
This should fix the issue. 

Using Javascript's in-built Date class is a bit flaxy. Moment is a better alternative. 

Line 46 in the home component was actually returning 1995-03-25T00:00:00.000Z  - one month out.

Before you merge this PR, I would build it on your machine as master won't compile on my machine (before my fix) because it looks like the git repo is missing environment files: ERROR in app/pages/build-info/build-info.component.ts:3:25 - error TS2307: Cannot find module '../../../environments/version'.

